### PR TITLE
nteract-binder badge

### DIFF
--- a/nteract_logo_cube_book/exports/images/svg/nteract_badge.svg
+++ b/nteract_logo_cube_book/exports/images/svg/nteract_badge.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de52c120d5e0ef9107446a546b46376188909a90ff5af40bd004fdcac25a4699
+size 956


### PR DESCRIPTION
I've created a badge to be used for launching the nteract interface on Binder. The badge use the same purple as the purple nteract logo. 

![nteract_badge](https://user-images.githubusercontent.com/2791223/44622131-d3f30700-a880-11e8-8154-2b3bfac72f98.png)

This could be useful for anyone who might want to distinguish between launching a Binder in the classic notebook versus an nteract notebook.

